### PR TITLE
fixed link url at en/index.md

### DIFF
--- a/docs/en/index.md
+++ b/docs/en/index.md
@@ -1,2 +1,2 @@
-This document is ECLWebRTC JavaScript SDK API Reference. See English version from [here](en/peer.md).
+This document is ECLWebRTC JavaScript SDK API Reference. See English version from [here](peer.md).
 See [Communication model of ECLWebRTC](https://webrtc.ecl.ntt.com/en/communication-model.html) if this is the first time for you to develop applciation with ECLWebRTC.

--- a/docs/ja/index.md
+++ b/docs/ja/index.md
@@ -1,2 +1,2 @@
-本ドキュメントは、SkyWay JavaScript SDKのAPIリファレンスです。日本語のドキュメントは[こちら](ja/peer.md)から。
+本ドキュメントは、SkyWay JavaScript SDKのAPIリファレンスです。日本語のドキュメントは[こちら](peer.md)から。
 SkyWayを使った開発が初めての場合は、SkyWayの[通信モデル](https://webrtc.ecl.ntt.com/communication-model.html)を先にご確認ください。


### PR DESCRIPTION
各言語のindexページにある here からのリンクURLを修正しました。

他にも相対パスで指定するところで、絶対パスでの指定になってないか確認しましたが、ざくっと見たところなさそうです。