### PR TITLE
Fix context about dcInit

### DIFF
--- a/docs/en/peer.md
+++ b/docs/en/peer.md
@@ -162,7 +162,7 @@ Create a new [DataConnection](../dataconnection) with Peer ID.
 | ------------- | -------------------- | -------- | ---------- | ---------------------------------------------------------------------------------- |
 | metadata      | Object               |          |            | Any additional data to send to the remote peer.                                    |
 | serialization | string               |          | `'binary'` | Serialization for data when sending. One of `'binary'`, `'json'`, or `'none'`.     |
-| dcInit        | [RTCDataChannelInit] |          | `{}`       | RTCDataChannelInit object passed into `createDataChannel()` to change reliability. It is defaulting to `true`. Note that Google Chrome uses `maxRetransmitTime` instead of `maxPacketLifetime`. |
+| dcInit        | [RTCDataChannelInit] |          | `{}`       | RTCDataChannelInit object passed into `createDataChannel()` to change reliability. It is defaulting to `true`. |
 | connectionId  | string               |          |            | The ID to identify each connection.                                                    |
 | label         | string               |          |            | **Deprecated!** The Label to identify each connection. Use `connectionId` instead.     |
 

--- a/docs/ja/peer.md
+++ b/docs/ja/peer.md
@@ -161,7 +161,7 @@ const call = peer.call('peerID', null, {
 |---------------|----------------------|----------|------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | metadata      | Object               |          |            | コネクションに関連付けされる任意のメタデータで、接続先のPeerに渡されます。                                                                                                          |
 | serialization | string               |          | `'binary'` | 送信時のシリアライズ方法を指定します。`'binary'`, `'json'`, `'none'`のいずれかとなります。                                                                                          |
-| dcInit        | [RTCDataChannelInit] |          | `{}`       | DataChannel利用時に信頼性の有無を指定するためのオプションです。デフォルトでは信頼性有で動作します。なお、Chromeは、`maxPacketLifetime`の代わりに、`maxRetransmitTime`を利用します。 |
+| dcInit        | [RTCDataChannelInit] |          | `{}`       | DataChannel利用時に信頼性の有無を指定するためのオプションです。デフォルトでは信頼性有で動作します。 |
 | connectionId  | string               |          |            | コネクションを識別するIDです。                                                                                                                                                      |
 | label         | string               |          |            | **Deprecated!** コネクションを識別するのに利用するラベルです。代わりに`connectionId`を使用してください。                                                                            |
 


### PR DESCRIPTION
Now, Chrome uses `maxPacketLifetime ` instead of `maxRetransmitTime`. 

[References]
- https://bugs.chromium.org/p/chromium/issues/detail?id=696681
- https://developer.mozilla.org/en-US/docs/Web/API/RTCDataChannel/maxPacketLifeTime